### PR TITLE
Nettoyage des géométries au téléchargement

### DIFF
--- a/cartiflette/download/dev.py
+++ b/cartiflette/download/dev.py
@@ -201,8 +201,6 @@ def download_admin_express(
         files = glob.glob(os.path.join(location, "**", "*.shp"), recursive=True)
         for file in files:
             success = sanitize_geoms(file)
-        
-        gpkg_archive = out_name
 
     arbo = glob.glob(f"{location}/**/1_DONNEES_LIVRAISON_*", recursive=True)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ s3fs
 PyYAML
 xlrd
 topojson
+shapely >= 1.8a3


### PR DESCRIPTION
Ajout d'une fonction pour nettoyer les géométries en lien avec https://github.com/InseeFrLab/cartiflette/issues/52.

J'ai testé la différence de résultat entre le `make_valid` de shapely et le `buffer(0)` de geopandas ; le premier donne des résultats plus fidèles. Par exemple sur le [2ème exemple](https://shapely.readthedocs.io/en/latest/manual.html#id32) fourni dans la doc de shapely, le buffer donnera un triangle alors que shapely donnera une collection triangle + ligne :

```
from shapely.validation import make_valid
from shapely.geometry import Polygon
coords = [(0, 2), (0, 1), (2, 0), (0, 0), (0, 2)]
p = Polygon(coords)
p.buffer(0).wkt
>>  'POLYGON ((0 1, 2 0, 0 0, 0 1))'
make_valid(p).wkt
>> 'GEOMETRYCOLLECTION (POLYGON ((2 0, 0 0, 0 1, 2 0)), LINESTRING (0 2, 0 1))'
```

Cela mériterait qu'on en discute plus largement (la geometry collection fonctionnera "bien" dans le cas d'une requête géo, mal je pense pour une insertion dans un postgre).

Dans le cas où l'on retient le make_valid de shapely, cela impose une dépendance à shapely >= 1.8a3.