### PR TITLE
Fix/sources IGN

### DIFF
--- a/cartiflette/utils/sources.yaml
+++ b/cartiflette/utils/sources.yaml
@@ -13,25 +13,41 @@ IGN:
         guyane: UTM22RGFG95_GUF
         reunion: RGR92UTM40S_REU
         mayotte: RGM04UTM38S_MYT
+      2024:
+        prefix: ADMIN-EXPRESS-COG
+        date: "2024-02-22"
+        version: "3-2"
+        url_prefix: https://data.geopf.fr/telechargement/download/
+        structure: "{url_prefix}{prefix}/{prefix}_{version}__SHP_{territory}_{date}/{prefix}_{version}__SHP_{territory}_{date}.7z"
+      2023:
+        prefix: ADMIN-EXPRESS-COG
+        date: "2023-05-03"
+        version: "3-2"
+        url_prefix: https://data.geopf.fr/telechargement/download/
+        structure: "{url_prefix}{prefix}/{prefix}_{version}__SHP_{territory}_{date}/{prefix}_{version}__SHP_{territory}_{date}.7z"
       2022:
         prefix: ADMIN-EXPRESS-COG
         date: "2022-04-15"
         version: "3-1"
-        url_prefix: https://wxs.ign.fr/x02uy2aiwjo9bm8ce5plwqmr/telechargement/prepackage/ADMINEXPRESS-COG_SHP_TERRITOIRES_PACK
-        structure: "{url_prefix}_{date}${prefix}_{version}__SHP_{territory}_{date}/file/{prefix}_{version}__SHP_{territory}_{date}.7z"
+        url_prefix: https://data.geopf.fr/telechargement/download/
+        structure: "{url_prefix}{prefix}/{prefix}_{version}__SHP_{territory}_{date}/{prefix}_{version}__SHP_{territory}_{date}.7z"
       2021:
         prefix: ADMIN-EXPRESS-COG
         date: "2021-05-19"
         version: "3-0"
-        url_prefix: https://wxs.ign.fr/x02uy2aiwjo9bm8ce5plwqmr/telechargement/prepackage/ADMINEXPRESS-COG_SHP_TERRITOIRES_PACK
-        structure: "{url_prefix}_{date}${prefix}_{version}__SHP_{territory}_{date}/file/{prefix}_{version}__SHP_{territory}_{date}.7z"
+        url_prefix: https://data.geopf.fr/telechargement/download/
+        structure: "{url_prefix}{prefix}/{prefix}_{version}__SHP_{territory}_{date}/{prefix}_{version}__SHP_{territory}_{date}.7z"
       2020:
+        # Nota : n'existe plus sous forme territoriale avec les URLs de la 
+        # géoplateforme, mais les anciennes URLs semblent toujours fonctionner
         prefix: ADMIN-EXPRESS-COG
-        date: "2020-11-20"
-        version: "2-1"
-        url_prefix: https://wxs.ign.fr/x02uy2aiwjo9bm8ce5plwqmr/telechargement/prepackage/ADMINEXPRESS-COG_SHP_TERRITOIRES_PACK_11-2020
+        date: "2019-09-24"
+        version: "2-0"
+        url_prefix: https://wxs.ign.fr/x02uy2aiwjo9bm8ce5plwqmr/telechargement/prepackage/ADMINEXPRESS-COG_SHP_TERRITOIRES_PACK_09-2019
         structure: "{url_prefix}${prefix}_{version}__SHP__FRA_{date}/file/{prefix}_{version}__SHP__FRA_{date}.7z"
       2019:
+        # Nota : n'existe plus sous forme territoriale avec les URLs de la 
+        # géoplateforme, mais les anciennes URLs semblent toujours fonctionner
         prefix: ADMIN-EXPRESS-COG
         date: "2019-09-24"
         version: "2-0"
@@ -39,26 +55,22 @@ IGN:
         structure: "{url_prefix}${prefix}_{version}__SHP__FRA_{date}/file/{prefix}_{version}__SHP__FRA_{date}.7z"
 
     EXPRESS-COG:
-      territory:
-        prefix: ADECOG_3-1_SHP_
-        metropole: LAMB93_FR
-        guadeloupe: RGAF09UTM20_D971
-        martinique: RGAF09UTM20_D972
-        guyane: UTM22RGFG95_D973
-        reunion: RGR92UTM40S_D974
-        mayotte: RGM04UTM38S_D976
+      2024:
+        file: https://data.geopf.fr/telechargement/download/ADMIN-EXPRESS-COG/ADMIN-EXPRESS-COG_3-2__SHP_WGS84G_FRA_2024-02-22/ADMIN-EXPRESS-COG_3-2__SHP_WGS84G_FRA_2024-02-22.7z
+      2023:
+        file: https://data.geopf.fr/telechargement/download/ADMIN-EXPRESS-COG/ADMIN-EXPRESS-COG_3-2__SHP_WGS84G_FRA_2023-05-03/ADMIN-EXPRESS-COG_3-2__SHP_WGS84G_FRA_2023-05-03.7z
       2022:
-        file: https://wxs.ign.fr/x02uy2aiwjo9bm8ce5plwqmr/telechargement/prepackage/ADMINEXPRESS_SHP_WGS84G_PACK_2022-06-21$ADMIN-EXPRESS_3-1__SHP__FRA_WM_2022-06-21/file/ADMIN-EXPRESS_3-1__SHP__FRA_WM_2022-06-21.7z
+        file: https://data.geopf.fr/telechargement/download/ADMIN-EXPRESS-COG/ADMIN-EXPRESS-COG_3-1__SHP_WGS84G_FRA_2022-04-15/ADMIN-EXPRESS-COG_3-1__SHP_WGS84G_FRA_2022-04-15.7z
       2021:
-        file: https://wxs.ign.fr/x02uy2aiwjo9bm8ce5plwqmr/telechargement/prepackage/ADMINEXPRESS-COG_SHP_WGS84G_PACK_2021-05-19$ADMIN-EXPRESS-COG_3-0__SHP_WGS84G_FRA_2021-05-19/file/ADMIN-EXPRESS-COG_3-0__SHP_WGS84G_FRA_2021-05-19.7z
+        file: https://data.geopf.fr/telechargement/download/ADMIN-EXPRESS-COG/ADMIN-EXPRESS-COG_3-0__SHP_WGS84G_FRA_2021-05-19/ADMIN-EXPRESS-COG_3-0__SHP_WGS84G_FRA_2021-05-19.7z
       2020:
-        file: https://wxs.ign.fr/x02uy2aiwjo9bm8ce5plwqmr/telechargement/prepackage/ADMINEXPRESS-COG_SHP_WGS84G_PACK_11-2020$ADMIN-EXPRESS-COG_2-1__SHP__FRA_2020-11-20/file/ADMIN-EXPRESS-COG_2-1__SHP__FRA_2020-11-20.7z
+        file: https://data.geopf.fr/telechargement/download/ADMIN-EXPRESS-COG/ADMIN-EXPRESS-COG_2-1__SHP__FRA_2020-11-20/ADMIN-EXPRESS-COG_2-1__SHP__FRA_2020-11-20.7z
       2019:
-        file: https://wxs.ign.fr/x02uy2aiwjo9bm8ce5plwqmr/telechargement/prepackage/ADMINEXPRESS-COG_SHP_WGS84G_PACK_09-2019$ADMIN-EXPRESS-COG_2-0__SHP__FRA_2019-09-24/file/ADMIN-EXPRESS-COG_2-0__SHP__FRA_2019-09-24.7z
+        file: https://data.geopf.fr/telechargement/download/ADMIN-EXPRESS-COG/ADMIN-EXPRESS-COG_2-0__SHP__FRA_2019-09-24/ADMIN-EXPRESS-COG_2-0__SHP__FRA_2019-09-24.7z
       2018:
-        file: https://wxs.ign.fr/x02uy2aiwjo9bm8ce5plwqmr/telechargement/prepackage/ADMINEXPRESS-COG-PACK_2018-04-01$ADMIN-EXPRESS-COG_1-1__SHP__FRA_2018-04-03/file/ADMIN-EXPRESS-COG_1-1__SHP__FRA_2018-04-03.7z
+        file: https://data.geopf.fr/telechargement/download/ADMIN-EXPRESS-COG/ADMIN-EXPRESS-COG_1-1__SHP__FRA_2018-04-03/ADMIN-EXPRESS-COG_1-1__SHP__FRA_2018-04-03.7z
       2017:
-        file: https://wxs.ign.fr/x02uy2aiwjo9bm8ce5plwqmr/telechargement/prepackage/ADMINEXPRESS-COG-PACK_2017-07-07$ADMIN-EXPRESS-COG_1-0__SHP__FRA_2017-06-19/file/ADMIN-EXPRESS-COG_1-0__SHP__FRA_2017-06-19.7z
+        file: https://data.geopf.fr/telechargement/download/ADMIN-EXPRESS-COG/ADMIN-EXPRESS-COG_1-0__SHP__FRA_2017-06-19/ADMIN-EXPRESS-COG_1-0__SHP__FRA_2017-06-19.7z
 
     EXPRESS-COG-CARTO-TERRITOIRE:
       territory:
@@ -68,80 +80,99 @@ IGN:
         guyane: UTM22RGFG95_GUF
         reunion: RGR92UTM40S_REU
         mayotte: RGM04UTM38S_MYT
+        
+      2024:
+        prefix: ADMIN-EXPRESS-COG-CARTO
+        date: "2024-02-22"
+        version: "3-2"
+        url_prefix: https://data.geopf.fr/telechargement/download/
+        structure: "{url_prefix}{prefix}/{prefix}_{version}__SHP_{territory}_{date}/{prefix}_{version}__SHP_{territory}_{date}.7z"
+      2023:
+        prefix: ADMIN-EXPRESS-COG-CARTO
+        date: "2023-05-03"
+        version: "3-2"
+        url_prefix: https://data.geopf.fr/telechargement/download/
+        structure: "{url_prefix}{prefix}/{prefix}_{version}__SHP_{territory}_{date}/{prefix}_{version}__SHP_{territory}_{date}.7z"
       2022:
         prefix: ADMIN-EXPRESS-COG-CARTO
         date: "2022-04-15"
         version: "3-1"
-        url_prefix: https://wxs.ign.fr/x02uy2aiwjo9bm8ce5plwqmr/telechargement/prepackage/ADMINEXPRESS-COG-CARTO_SHP_TERRITOIRES_PACK
-        structure: "{url_prefix}_{date}${prefix}_{version}__SHP_{territory}_{date}/file/{prefix}_{version}__SHP_{territory}_{date}.7z"
+        url_prefix: https://data.geopf.fr/telechargement/download/
+        structure: "{url_prefix}{prefix}/{prefix}_{version}__SHP_{territory}_{date}/{prefix}_{version}__SHP_{territory}_{date}.7z"
       2021:
         prefix: ADMIN-EXPRESS-COG-CARTO
         date: "2021-05-19"
         version: "3-0"
-        url_prefix: https://wxs.ign.fr/x02uy2aiwjo9bm8ce5plwqmr/telechargement/prepackage/ADMINEXPRESS-COG-CARTO_SHP_TERRITOIRES_PACK
-        structure: "{url_prefix}_{date}${prefix}_{version}__SHP_{territory}_{date}/file/{prefix}_{version}__SHP_{territory}_{date}.7z"
+        url_prefix: https://data.geopf.fr/telechargement/download/
+        structure: "{url_prefix}{prefix}/{prefix}_{version}__SHP_{territory}_{date}/{prefix}_{version}__SHP_{territory}_{date}.7z"
 
     EXPRESS-COG-CARTO:
+      2024:
+        file: https://data.geopf.fr/telechargement/download/ADMIN-EXPRESS-COG-CARTO/ADMIN-EXPRESS-COG-CARTO_3-2__SHP_WGS84G_FRA_2024-02-22/ADMIN-EXPRESS-COG-CARTO_3-2__SHP_WGS84G_FRA_2024-02-22.7z
+      2023:
+        file: https://data.geopf.fr/telechargement/download/ADMIN-EXPRESS-COG-CARTO/ADMIN-EXPRESS-COG-CARTO_3-2__SHP_WGS84G_FRA_2023-05-03/ADMIN-EXPRESS-COG-CARTO_3-2__SHP_WGS84G_FRA_2023-05-03.7z
       2022:
-        file: https://wxs.ign.fr/x02uy2aiwjo9bm8ce5plwqmr/telechargement/prepackage/ADMINEXPRESS-COG-CARTO_SHP_WGS84G_PACK_2022-04-15$ADMIN-EXPRESS-COG-CARTO_3-1__SHP_WGS84G_FRA_2022-04-15/file/ADMIN-EXPRESS-COG-CARTO_3-1__SHP_WGS84G_FRA_2022-04-15.7z
+        file: https://data.geopf.fr/telechargement/download/ADMIN-EXPRESS-COG-CARTO/ADMIN-EXPRESS-COG-CARTO_3-1__SHP_WGS84G_FRA_2022-04-15/ADMIN-EXPRESS-COG-CARTO_3-1__SHP_WGS84G_FRA_2022-04-15.7z
       2021:
-        file: https://wxs.ign.fr/x02uy2aiwjo9bm8ce5plwqmr/telechargement/prepackage/ADMINEXPRESS-COG-CARTO_SHP_WGS84G_PACK_2021-05-19$ADMIN-EXPRESS-COG-CARTO_3-0__SHP_WGS84G_FRA_2021-05-19/file/ADMIN-EXPRESS-COG-CARTO_3-0__SHP_WGS84G_FRA_2021-05-19.7z
+        file: https://data.geopf.fr/telechargement/download/ADMIN-EXPRESS-COG-CARTO/ADMIN-EXPRESS-COG-CARTO_3-0__SHP_WGS84G_FRA_2021-05-19/ADMIN-EXPRESS-COG-CARTO_3-0__SHP_WGS84G_FRA_2021-05-19.7z
 
   BDTOPO:
   
     pattern: "*DONNEES_LIVRAISON*.shp"
-    structure: "{url_prefix}_{year}.1${prefix}_{version}_ADMINISTRATIF_SHP_{territory}_{date}/file/{prefix}_{version}_ADMINISTRATIF_SHP_{territory}_{date}.7z"
+    structure: "{url_prefix}{prefix}/{prefix}_{version}_ADMINISTRATIF_SHP_{territory}_{date}/{prefix}_{version}_ADMINISTRATIF_SHP_{territory}_{date}.7z"
     ROOT:
       territory:
         france_entiere: WGS84G_FRA
       2018:
         prefix: BDTOPO
-        year: "18"
         date: "2018-01-01"
         version: "2-2"
-        url_prefix: https://wxs.ign.fr/859x8t863h6a09o9o6fy4v60/telechargement/inspire/BDTOPO-FRANCE-ADMIN-SSDOUBLON-PACK
+        url_prefix: https://data.geopf.fr/telechargement/download/
       2017:
         prefix: BDTOPO
-        year: "17"
         date: "2017-01-01"
         version: "2-2"
-        url_prefix: https://wxs.ign.fr/859x8t863h6a09o9o6fy4v60/telechargement/inspire/BDTOPO-FRANCE-ADMIN-SSDOUBLON-PACK
+        url_prefix: https://data.geopf.fr/telechargement/download/
       2016:
         prefix: BDTOPO
-        year: "16"
         date: "2016-01-01"
         version: "2-1"
-        url_prefix: https://wxs.ign.fr/859x8t863h6a09o9o6fy4v60/telechargement/inspire/BDTOPO-FRANCE-ADMIN-SSDOUBLON-PACK
+        url_prefix: https://data.geopf.fr/telechargement/download/
       2015:
         prefix: BDTOPO
-        year: "15"
         date: "2015-01-01"
         version: "2-1"
-        url_prefix: https://wxs.ign.fr/859x8t863h6a09o9o6fy4v60/telechargement/inspire/BDTOPO-FRANCE-ADMIN-SSDOUBLON-PACK
+        url_prefix: https://data.geopf.fr/telechargement/download/
       2014:
         prefix: BDTOPO
-        year: "14"
         date: "2014-01-01"
         version: "2-1"
-        url_prefix: https://wxs.ign.fr/859x8t863h6a09o9o6fy4v60/telechargement/inspire/BDTOPO-FRANCE-ADMIN-SSDOUBLON-PACK
+        url_prefix: https://data.geopf.fr/telechargement/download/
       2013:
         prefix: BDTOPO
-        year: "13"
         date: "2013-01-01"
         version: "2-1"
-        url_prefix: https://wxs.ign.fr/859x8t863h6a09o9o6fy4v60/telechargement/inspire/BDTOPO-FRANCE-ADMIN-SSDOUBLON-PACK
+        url_prefix: https://data.geopf.fr/telechargement/download/
+      2012:
+        prefix: BDTOPO
+        date: "2013-01-01"
+        version: "2-1"
+        url_prefix: https://data.geopf.fr/telechargement/download/
+      2011:
+        prefix: BDTOPO
+        date: "2011-01-01"
+        version: "2-0"
+        url_prefix: https://data.geopf.fr/telechargement/download/
       2010:
         prefix: BDTOPO
-        year: "10"
         date: "2010-01-01"
         version: "2-0"
-        url_prefix: https://wxs.ign.fr/859x8t863h6a09o9o6fy4v60/telechargement/inspire/BDTOPO-FRANCE-ADMIN-SSDOUBLON-PACK
+        url_prefix: https://data.geopf.fr/telechargement/download/
       2009:
         prefix: BDTOPO
-        year: "09"
         date: "2009-01-01"
         version: "2-0"
-        url_prefix: https://wxs.ign.fr/859x8t863h6a09o9o6fy4v60/telechargement/inspire/BDTOPO-FRANCE-ADMIN-SSDOUBLON-PACK
+        url_prefix: https://data.geopf.fr/telechargement/download/
 
   CONTOUR-IRIS: #variables INSEE_COM NOM_COM IRIS CODE_IRIS NOM_IRIS TYP_IRIS ; manque la var Grand-Quartier (GRD_QUART) présente sur les tables insee https://www.insee.fr/fr/information/2017499
     

--- a/cartiflette/utils/sources.yaml
+++ b/cartiflette/utils/sources.yaml
@@ -399,19 +399,27 @@ Insee:
         filename: pays2017-txt.zip  
 
   TAGC:
-    structure: https://www.insee.fr/fr/statistiques/fichier/2028028/{filename}    
-    APPARTENANCE:
+    structure: https://www.insee.fr/fr/statistiques/fichier/{article}/{filename}
+    APPARTENANCE:  
+      2024:
+        article: "7671844"
+        pattern: "*.xlsx"
+        filename: "table-appartenance-geo-communes-2024.zip"
       2023:
+        article: "7671844"
         pattern: "*.xlsx"
         filename: "table-appartenance-geo-communes-23.zip"
       2022:
+        article: "7671844"
         pattern: "*.xlsx"
         filename: "table-appartenance-geo-communes-22.zip"
+    
     PASSAGE_ANNUEL:
       # Pour cette source, juste besoin de la derniere version
-      2023:
+      2024:
+        article: "7671867"
         pattern: "*.xlsx"
-        filename: "table_passage_annuelle_2023.zip"
+        filename: "table_passage_annuelle_2024.zip"
 
   BV:
     pattern: "com_bv*.dbf"
@@ -421,9 +429,11 @@ Insee:
         file: https://www.insee.fr/fr/statistiques/fichier/6676988/fonds_bv2022_2023.zip
       2022:
         file: https://www.insee.fr/fr/statistiques/fichier/6676988/fonds_bv2022_2022.zip
-    FondsDeCarte_BV_2012:
-      2022:
-        file: https://www.insee.fr/fr/statistiques/fichier/2115016/fonds_bv2012_2022.zip
+    
+    # Source disparue :
+    # FondsDeCarte_BV_2012:
+    #   2022:
+    #     file: https://www.insee.fr/fr/statistiques/fichier/2115016/fonds_bv2012_2022.zip
       
   
   # UU2020:


### PR DESCRIPTION
Correction des sources de la géoplateforme de l'IGN :
* pour admin-express (hors admin-express-cog-territoire 2020 et 2019, aujourd'hui disparus, mais dont les anciennes URLs semblent toujours fonctionner)
* pour la BDTOPO

Correction des source du site de l'INSEE :
* retrait des bassins de vie 2012 des sources (disparus du site de l'INSEE)
* mise à jour des sources TAGC (changement d'articles + dissociation des jeux APPARTENANCE et PASSAGE_ANNUEL sur le site de l'INSEE)
