### PR TITLE
Correction des conflits de version sur pytest pour les tests automatisés

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         poetry install --without dev
-        poetry add pytest
+        poetry run pip install pytest
     - name: Test import
       run: |
         export AWS_ACCESS_KEY_ID=${{ secrets.S3_ACCESS_KEY }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ qt6 = ["PyQt6"]
 
 [tool.poetry.group.dev.dependencies]
 spyder = "^5.4.2"
-pytest = "^7.2.2"
+pytest = "^8.1.1"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Ne corrige pas tous les tests, il subsiste pas mal d'erreurs à traiter.
(Le premier échec relatif aux sources est couvert par la PR précédente.)